### PR TITLE
Make SSH key optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ module "terraform-aws-xlt-loadtest" {
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | allowed\_networks | The allowed networks IP/32 | list(string) | n/a | yes |
-| keyname | The existing keyname of the keypair used for connecting with ssh to the agents | string | n/a | yes |
 | name | The name used for further interpolastion | string | n/a | yes |
 | password | The password to use | string | n/a | yes |
 | ami | The AMI used for the agents | string | `"ami-0f74bf64551726b45"` | no |
@@ -49,6 +48,7 @@ module "terraform-aws-xlt-loadtest" {
 | grafana\_enabled | Do we create a custom Grafana instance | bool | `"false"` | no |
 | instance\_count | The amount of instances to start | string | `"2"` | no |
 | instance\_type | The default instance_type | string | `"c4.2xlarge"` | no |
+| keyname | The existing keyname of the keypair used for connecting with ssh to the agents | string | `""` | no |
 | local\_network | The vpc network | string | `"10.0.0.0/16"` | no |
 | start\_port\_services | The first agent of many will be exposed at port 5000 of the NLB, the second on 5001 etc.etc. | number | `"5000"` | no |
 | start\_port\_ssh | The first ssh of the agents will be exposed at port 6000 of the NLB, the second on 6001 etc.etc. | number | `"6000"` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,7 @@ variable "name" {
 
 variable "keyname" {
   description = "The existing keyname of the keypair used for connecting with ssh to the agents"
+  default     = ""
   type        = string
 }
 


### PR DESCRIPTION
# Make SSH key optional

This PR removes the need to specify an SSH key name by making it optional.